### PR TITLE
[Website] adding DOAP file for projects.apache.org

### DIFF
--- a/docs/doap.rdf
+++ b/docs/doap.rdf
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="http://zeppelin.incubator.apache.org/">
+    <created>2015-09-12</created>
+    <license rdf:resource="http://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Zeppelin (incubating)</name>
+    <homepage rdf:resource="http://zeppelin.incubator.apache.org/" />
+    <asfext:pmc rdf:resource="http://incubator.apache.org" />
+    <shortdesc>Zeppelin is a collaborative data analytics and visualization tool for distributed, general-purpose data processing systems</shortdesc>
+    <description>Zeppelin is a modern web-based tool for the data scientists to collaborate over large-scale data exploration and visualization projects. </description>
+    <bug-database rdf:resource="https://issues.apache.org/jira/browse/ZEPPELIN" />
+    <mailing-list rdf:resource="http://zeppelin.incubator.apache.org/community.html" />
+    <download-page rdf:resource="http://zeppelin.incubator.apache.org/download.html" />
+    <programming-language>Java</programming-language>
+    <programming-language>JavaScript</programming-language>
+    <programming-language>Scala</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/big-data" />
+    <release>
+      <Version>
+        <name>0.5.0-incubating</name>
+        <created>2015-07-31</created>
+        <revision>0.5.0-incubating</revision>
+      </Version>
+    </release>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/incubator-zeppelin.git"/>
+        <browse rdf:resource="https://git1-us-west.apache.org/repos/asf?p=incubator-zeppelin.git;a=summary"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Alexander Bezzubov</foaf:name>
+          <foaf:mbox rdf:resource="mailto:bzz@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>


### PR DESCRIPTION
This PR adds a hand-crafted description of Zeppelin project in RDF to be listed
at [projects.apache.org](https://projects.apache.org/project.html?zeppelin)
