### PR TITLE
Fix bugs in search front-end

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -71,13 +71,18 @@ angular.module('zeppelinWebApp').controller('NotebookCtrl',
     var currentRoute = $route.current;
 
     if (currentRoute) {
-      var routeParams = currentRoute.params;
-      var id = '#' + routeParams.paragraph + '_container';
+
       setTimeout(
         function() {
-          // adjust for navbar
-          var top = $(id).offset().top - 103;
-          $('html, body').scrollTo({top: top, left: 0});
+          var routeParams = currentRoute.params;
+          var $id = $('#' + routeParams.paragraph + '_container');
+
+          if ($id.length > 0) {
+            // adjust for navbar
+            var top = $id.offset().top - 103;
+            $('html, body').scrollTo({top: top, left: 0});
+          }
+
         },
         1000
       );

--- a/zeppelin-web/src/app/search/result-list.controller.js
+++ b/zeppelin-web/src/app/search/result-list.controller.js
@@ -22,6 +22,12 @@ angular
 
   results.$promise.then(function(result) {
     $scope.notes = result.body.map(function(note) {
+      // redirect to notebook when search result is a notebook itself,
+      // not a paragraph
+      if (!/\/paragraph\//.test(note.id)) {
+        return note;
+      }
+
       note.id = note.id.replace('paragraph/', '?paragraph=') +
         '&term=' +
         $routeParams.searchTerm;

--- a/zeppelin-web/src/app/search/search.css
+++ b/zeppelin-web/src/app/search/search.css
@@ -1,3 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .search-results {
   list-style-type: none;
   margin: 10% auto 0;


### PR DESCRIPTION
### scope
- [x] check for paragraph param in url before trying to scroll to it
- [x] handle a case when search returns a link to a notebook itself (as opposite to a
  specific paragraph)
- [x] add missing license info
### how to test this PR
1. Go to any notebook from zeppelin main screen (not from search) and see no [error](https://cloud.githubusercontent.com/assets/1540981/11826002/f5a11f3a-a3c5-11e5-8e74-9dfdbb814bfa.png) in console
2. Search for a notebook by name and be sure it search results redirect to it correctly
