### PR TITLE
Backport https://github.com/plusjade/jekyll-bootstrap/pull/293

### DIFF
--- a/_includes/JB/pages_list
+++ b/_includes/JB/pages_list
@@ -28,9 +28,9 @@ Usage:
       {% for cat in node.group %}
         {% if cat == group %}
           {% if page.url == node.url %}
-            <li class="active"><a href="{{ BASE_PATH }}{{node.url}}" class="active">{{node.title}}</a></li>
+            <li class="active"><a href="{{ BASE_PATH }}{{node.url}}.html" class="active">{{node.title}}</a></li>
           {% else %}
-            <li><a href="{{ BASE_PATH }}{{node.url}}">{{node.title}}</a></li>
+            <li><a href="{{ BASE_PATH }}{{node.url}}.html">{{node.title}}</a></li>
           {% endif %}
         {% endif %}
       {% endfor %}

--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -17,7 +17,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
-    {% endif %}  
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{% if page.theme.name %}{{ page.theme.name }}{% else if %}{{ layout.theme.name }}{% endif %}{% endcapture %}
+    {% endif %}
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
### What is this PR for?

Fix other version changes after jekyll Bump
### What type of PR is it?

Bug Fix
### Todos
- [X] - Fix theme name missing for assets 
- [x] - Links produced by page_list don't have the .html extension anymore (giving 404)
